### PR TITLE
zanoza: use stable packages

### DIFF
--- a/systems/x86_64-linux/zanoza/default.nix
+++ b/systems/x86_64-linux/zanoza/default.nix
@@ -2,6 +2,7 @@
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 {
+  inputs,
   pkgs,
   lib,
   ...
@@ -9,6 +10,7 @@
   system = "x86_64-linux";
   hostName = "zanoza";
 in {
+  _module.args.pkgs = inputs.stable.legacyPackages.${system};
   imports = [
     # Include the results of the hardware scan.
     ./hardware-configuration.nix


### PR DESCRIPTION
## Summary
- use stable channel for zanoza by overriding pkgs

## Testing
- `nix --extra-experimental-features 'nix-command flakes' fmt systems/x86_64-linux/zanoza/default.nix` *(fails: unable to download 'https://cache.nixos.org')*
- `nix --extra-experimental-features 'nix-command flakes' build .#nixosConfigurations.zanoza.config.system.build.toplevel` *(fails: download interrupted)*
- `nix --extra-experimental-features 'nix-command flakes' flake check` *(fails: unable to download 'https://cache.nixos.org')*
- `nix --extra-experimental-features 'nix-command flakes' run .#deploy.zanoza` *(fails: unable to download 'https://cache.nixos.org')*


------
https://chatgpt.com/codex/tasks/task_b_68c3d17b46a4832abef255cbb536d81b