### PR TITLE
feat(sops): export age key file path

### DIFF
--- a/modules/shared/security/sops/default.nix
+++ b/modules/shared/security/sops/default.nix
@@ -67,6 +67,9 @@ in {
         sops
         ssh-to-age
       ];
+
+      home.sessionVariables.SOPS_AGE_KEY_FILE =
+        "${config.home.homeDirectory}/.config/sops/age/keys.txt";
     })
 
     # SOPS configuration (platform-agnostic)


### PR DESCRIPTION
## Summary
- export `SOPS_AGE_KEY_FILE` using the shared SOPS module

## Testing
- `nix --extra-experimental-features 'nix-command flakes' fmt modules/shared/security/sops/default.nix` *(fails: flake 'git+file:///workspace/dotnix' does not provide attribute 'formatter.x86_64-linux')*
- `nix --extra-experimental-features 'nix-command flakes' flake check` *(fails: unable to download 'https://st.ktalk.host/ktalk-app/linux/ktalk3.2.0-beta.2x86_64.AppImage')*

------
https://chatgpt.com/codex/tasks/task_b_68c4061d2720832a8eb7478baf0d24eb