### PR TITLE
feat(gtk): apply cyberdream popover styling

### DIFF
--- a/modules/nixos/desktop/addons/gtk/cyberdream.css
+++ b/modules/nixos/desktop/addons/gtk/cyberdream.css
@@ -1,0 +1,145 @@
+/* Cyberdream palette extracted from ReGreet */
+@define-color cd-bg         #0f1113;
+@define-color cd-bg-ov      rgba(15,17,19,0.55);
+@define-color cd-surface    #191d22;
+@define-color cd-surface-2  #1f252b;
+@define-color cd-border     #2b323a;
+
+@define-color cd-text       #e6edf3;
+@define-color cd-subtext    #c1cad6;
+@define-color cd-muted      #97a4b6;
+
+@define-color cd-blue       #5ea1ff;
+@define-color cd-cyan       #5ef1ff;
+@define-color cd-green      #78f093;
+@define-color cd-yellow     #ffd76b;
+@define-color cd-red        #ff6b82;
+@define-color cd-magenta    #ff5ef1;
+
+/* Dark popovers and menus */
+popover,
+popover.background,
+menu,
+.menu {
+  background: @cd-surface !important;
+  color: @cd-text !important;
+  border: 1px solid @cd-border !important;
+  border-radius: 12px !important;
+  box-shadow: none !important;
+}
+
+popover *,
+popover.background * {
+  background: @cd-surface !important;
+  color: @cd-text !important;
+}
+
+popover > contents,
+popover contents,
+popover box,
+popover scrolledwindow,
+popover viewport,
+popover .view,
+popover list,
+popover listview,
+popover flowbox {
+  background: @cd-surface !important;
+  color: @cd-text !important;
+}
+
+popover list row,
+popover listview row,
+menuitem,
+modelbutton {
+  background: transparent !important;
+  color: @cd-text !important;
+}
+
+popover list row:hover,
+popover listview row:hover,
+menuitem:hover,
+modelbutton:hover {
+  background: @cd-surface-2 !important;
+}
+
+popover list row:selected,
+popover listview row:selected,
+menuitem:active,
+menuitem:checked,
+modelbutton:active,
+modelbutton:checked {
+  background: alpha(@cd-blue, 0.18) !important;
+  color: @cd-text !important;
+}
+
+popover separator,
+menu separator {
+  background-color: alpha(@cd-border, 0.6) !important;
+}
+
+/* Additional GTK4 dropdown/combobox popovers */
+dropdown popover,
+dropdown popover.background,
+dropdown popover > contents,
+dropdown popover listview,
+dropdown popover list,
+dropdown popover .view,
+dropdown popover row,
+dropdown popover scrolledwindow,
+dropdown popover viewport,
+dropdown popover *,
+dropdown popover.background * {
+  background: @cd-surface !important;
+  color: @cd-text !important;
+  border-color: @cd-border !important;
+}
+
+combobox popover,
+combobox popover.background,
+combobox popover > contents,
+combobox popover listview,
+combobox popover list,
+combobox popover .view,
+combobox popover row,
+combobox popover scrolledwindow,
+combobox popover viewport,
+combobox popover *,
+combobox popover.background * {
+  background: @cd-surface !important;
+  color: @cd-text !important;
+  border-color: @cd-border !important;
+}
+
+menubutton popover,
+menubutton popover.background,
+menubutton popover > contents,
+menubutton popover listview,
+menubutton popover list,
+menubutton popover .view,
+menubutton popover row,
+menubutton popover scrolledwindow,
+menubutton popover viewport,
+menubutton popover *,
+menubutton popover.background * {
+  background: @cd-surface !important;
+  color: @cd-text !important;
+  border-color: @cd-border !important;
+}
+
+menubutton row,
+combobox row,
+dropdown row {
+  background: transparent !important;
+}
+
+menubutton row:hover,
+combobox row:hover,
+dropdown row:hover {
+  background: @cd-surface-2 !important;
+}
+
+menubutton row:selected,
+combobox row:selected,
+dropdown row:selected {
+  background: alpha(@cd-blue, 0.18) !important;
+}

--- a/modules/nixos/desktop/addons/gtk/default.nix
+++ b/modules/nixos/desktop/addons/gtk/default.nix
@@ -1,22 +1,19 @@
-{
-  options,
-  config,
-  lib,
-  pkgs,
-  ...
-}:
-with lib;
-with lib.custom; let
+{ options, config, lib, pkgs, ... }:
+let
+  inherit (lib) mkIf;
+  inherit (lib.custom) mkBoolOpt;
   cfg = config.custom.desktop.addons.gtk;
+  cyberdreamCss = builtins.readFile ./cyberdream.css;
 in {
-  options.custom.desktop.addons.gtk = with types; {
+  options.custom.desktop.addons.gtk = {
     enable = mkBoolOpt false "Whether to customize GTK and apply themes.";
 
     home.config = mkIf cfg.enable {
       gtk = {
         enable = true;
+
         theme = {
-          name = "Adwaita";
+          name = "Adwaita-dark";
           package = pkgs.gnome.adwaita-icon-theme;
         };
         iconTheme = {
@@ -30,6 +27,9 @@ in {
 
         font.name = "System-ui Regular";
         font.size = 11;
+
+        gtk3.extraCss = cyberdreamCss;
+        gtk4.extraCss = cyberdreamCss;
       };
     };
   };


### PR DESCRIPTION
## Summary
- extract the cyberdream palette and popover styling into a reusable GTK stylesheet
- wire the stylesheet into the GTK module so both GTK3 and GTK4 use the dark overrides
- switch the GTK theme default to Adwaita-dark to align with the cyberdream accents

## Testing
- not run (environment not configured for Nix builds)


------
https://chatgpt.com/codex/tasks/task_b_68dd12dd8304832a851a5cd3aab13968